### PR TITLE
feat: 사용자 소속 및 구분 관리 기능 추가 (주 소속, 서브 소속, 구분)

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/AdminUpdateUserRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/AdminUpdateUserRequest.java
@@ -1,7 +1,7 @@
 package com.bmilab.backend.domain.user.dto.request;
 
 import com.bmilab.backend.domain.user.enums.Role;
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -35,10 +35,13 @@ public record AdminUpdateUserRequest(
         @Size(max = 20, message = "부서명은 20자 이하로 입력해주세요.")
         String department,
 
-        @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
+        @Schema(description = "구분 (있으면)", example = "MASTERS_STUDENT")
         @Nullable
-        @Size(max = 20, message = "소속은 50자 이하로 입력해주세요.")
-        UserAffiliation affiliation,
+        UserPosition position,
+
+        @Schema(description = "서브 소속 (있으면)")
+        @Nullable
+        List<UserSubAffiliationRequest> subAffiliations,
 
         @Schema(description = "권한")
         @NotBlank(message = "권한은 필수입니다.")

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/RegisterUserRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/RegisterUserRequest.java
@@ -1,7 +1,7 @@
 package com.bmilab.backend.domain.user.dto.request;
 
 import com.bmilab.backend.domain.user.enums.Role;
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -42,9 +42,13 @@ public record RegisterUserRequest(
         @Size(max = 20, message = "부서명은 20자 이하로 입력해주세요.")
         String department,
 
-        @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
+        @Schema(description = "구분 (있으면)", example = "MASTERS_STUDENT")
         @Nullable
-        UserAffiliation affiliation,
+        UserPosition position,
+
+        @Schema(description = "서브 소속 (있으면)")
+        @Nullable
+        List<UserSubAffiliationRequest> subAffiliations,
 
         @Schema(description = "권한")
         @NotBlank(message = "권한은 필수입니다.")

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/UpdateUserRequest.java
@@ -1,6 +1,6 @@
 package com.bmilab.backend.domain.user.dto.request;
 
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import com.bmilab.backend.global.validation.RegExp;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -33,9 +33,13 @@ public record UpdateUserRequest(
         @Size(max = 20, message = "부서명은 20자 이하로 입력해주세요.")
         String department,
 
-        @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
+        @Schema(description = "구분 (있으면)", example = "MASTERS_STUDENT")
         @Nullable
-        UserAffiliation affiliation,
+        UserPosition position,
+
+        @Schema(description = "서브 소속 (있으면)")
+        @Nullable
+        List<UserSubAffiliationRequest> subAffiliations,
 
         @Schema(description = "추가된 연구 분야 ID 목록", example = "[1, 2, 3]")
         @Nullable

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/UserAccountEmailRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/UserAccountEmailRequest.java
@@ -1,10 +1,12 @@
 package com.bmilab.backend.domain.user.dto.request;
 
 import com.bmilab.backend.global.validation.RegExp;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record UserAccountEmailRequest(
+        @Schema(name = "비밀번호", example = "SecurePass123!")
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Pattern(regexp = RegExp.PASSWORD_EXPRESSION, message = RegExp.PASSWORD_MESSAGE)
         String password

--- a/src/main/java/com/bmilab/backend/domain/user/dto/request/UserSubAffiliationRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/request/UserSubAffiliationRequest.java
@@ -1,0 +1,24 @@
+package com.bmilab.backend.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserSubAffiliationRequest(
+        @Schema(description = "기관", example = "국민대학교")
+        @NotBlank
+        @Size(max = 50)
+        String organization,
+
+        @Schema(description = "부서", example = "소프트웨어학부")
+        @Nullable
+        @Size(max = 20)
+        String department,
+
+        @Schema(description = "구분", example = "학부생")
+        @Nullable
+        @Size(max = 20)
+        String position
+) {
+}

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/UserDetail.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/UserDetail.java
@@ -7,8 +7,9 @@ import com.bmilab.backend.domain.user.dto.query.UserDetailQueryResult;
 import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.entity.UserEducation;
 import com.bmilab.backend.domain.user.entity.UserInfo;
+import com.bmilab.backend.domain.user.entity.UserSubAffiliation;
 import com.bmilab.backend.domain.user.enums.Role;
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
@@ -31,8 +32,11 @@ public record UserDetail(
         @Schema(description = "부서", example = "개발팀")
         String department,
 
-        @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
-        UserAffiliation affiliation,
+        @Schema(description = "구분 (있으면)", example = "MASTERS_STUDENT")
+        UserPosition position,
+
+        @Schema(description = "서브 소속 목록")
+        List<UserSubAffiliationSummary> subAffiliation,
 
         @Schema(description = "사용자 역할", example = "USER")
         Role role,
@@ -63,11 +67,13 @@ public record UserDetail(
 
         @Schema(description = "입사일", example = "2023-03-01")
         LocalDate joinedAt
+
 ) {
     public static UserDetail from(
             UserDetailQueryResult queryResult,
             List<UserEducation> educations,
             List<ProjectCategory> categories,
+            List<UserSubAffiliation> subAffiliations,
             boolean includeComment
     ) {
         User user = queryResult.user();
@@ -81,7 +87,8 @@ public record UserDetail(
                 .name(user.getName())
                 .organization(user.getOrganization())
                 .department(user.getDepartment())
-                .affiliation(user.getAffiliation())
+                .position(user.getPosition())
+                .subAffiliation(subAffiliations.stream().map(UserSubAffiliationSummary::from).toList())
                 .role(user.getRole())
                 .profileImageUrl(user.getProfileImageUrl())
                 .comment((includeComment) ? userInfo.getComment() : null)

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/UserFindAllResponse.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/UserFindAllResponse.java
@@ -5,7 +5,7 @@ import com.bmilab.backend.domain.user.dto.query.UserCondition;
 import com.bmilab.backend.domain.user.dto.query.UserInfoQueryResult;
 import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.entity.UserInfo;
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import org.springframework.data.domain.Page;
@@ -57,8 +57,8 @@ public record UserFindAllResponse(
             @Schema(description = "부서", example = "개발팀")
             String department,
 
-            @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
-            UserAffiliation affiliation,
+            @Schema(description = "구분 (있으면)", example = "MASTERS_STUDENT")
+            UserPosition position,
 
             @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profiles/user1.png")
             String profileImageUrl,
@@ -85,7 +85,7 @@ public record UserFindAllResponse(
                     .name(user.getName())
                     .organization(user.getOrganization())
                     .department(user.getDepartment())
-                    .affiliation(user.getAffiliation())
+                    .position(user.getPosition())
                     .profileImageUrl(user.getProfileImageUrl())
                     .categories(
                             queryResult.getCategories()

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/UserSubAffiliationSummary.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/UserSubAffiliationSummary.java
@@ -1,0 +1,22 @@
+package com.bmilab.backend.domain.user.dto.response;
+
+import com.bmilab.backend.domain.user.entity.UserSubAffiliation;
+import lombok.Builder;
+
+@Builder
+public record UserSubAffiliationSummary(
+        String organization,
+
+        String department,
+
+        String position
+) {
+    public static UserSubAffiliationSummary from(UserSubAffiliation userSubAffiliation) {
+        return UserSubAffiliationSummary
+                .builder()
+                .organization(userSubAffiliation.getOrganization())
+                .department(userSubAffiliation.getDepartment())
+                .position(userSubAffiliation.getPosition())
+                .build();
+    }
+}

--- a/src/main/java/com/bmilab/backend/domain/user/dto/response/UserSummary.java
+++ b/src/main/java/com/bmilab/backend/domain/user/dto/response/UserSummary.java
@@ -1,7 +1,7 @@
 package com.bmilab.backend.domain.user.dto.response;
 
 import com.bmilab.backend.domain.user.entity.User;
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -22,8 +22,8 @@ public record UserSummary(
         @Schema(description = "부서", example = "개발팀")
         String department,
 
-        @Schema(description = "소속 (있으면)", example = "MASTERS_STUDENT")
-        UserAffiliation affiliation,
+        @Schema(description = "직책 (있으면)", example = "MASTERS_STUDENT")
+        UserPosition position,
 
         @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profiles/user1.png")
         String profileImageUrl
@@ -36,7 +36,7 @@ public record UserSummary(
                 .name(user.getName())
                 .organization(user.getOrganization())
                 .department(user.getDepartment())
-                .affiliation(user.getAffiliation())
+                .position(user.getPosition())
                 .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }

--- a/src/main/java/com/bmilab/backend/domain/user/entity/User.java
+++ b/src/main/java/com/bmilab/backend/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.bmilab.backend.domain.user.entity;
 
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import com.bmilab.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,21 +38,20 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    private String organization;
+
+    private String department;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "position")
+    private UserPosition position;
+
     @Column(name = "profile_image_url", columnDefinition = "TEXT")
     private String profileImageUrl;
 
-    @Column(nullable = false)
-    private String department;
-
-    @Column(nullable = false)
-    private String organization;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "affiliation")
-    private UserAffiliation affiliation;
-
     @Enumerated(EnumType.STRING)
     private Role role;
+
 
     public void updatePassword(String newPassword) {
         this.password = newPassword;
@@ -62,12 +61,12 @@ public class User extends BaseTimeEntity {
         this.profileImageUrl = newProfileImageUrl;
     }
 
-    public void update(String name, String email, String organization, String department, UserAffiliation affiliation) {
+    public void update(String name, String email, String organization, String department, UserPosition position) {
         this.name = name;
         this.email = email;
         this.department = department;
         this.organization = organization;
-        this.affiliation = affiliation;
+        this.position = position;
     }
 
     public void updateRole(Role role) {

--- a/src/main/java/com/bmilab/backend/domain/user/entity/UserSubAffiliation.java
+++ b/src/main/java/com/bmilab/backend/domain/user/entity/UserSubAffiliation.java
@@ -1,0 +1,43 @@
+package com.bmilab.backend.domain.user.entity;
+
+import com.bmilab.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Table(name = "user_sub_affiliations")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSubAffiliation extends BaseTimeEntity {
+    @Id
+    @Column(name = "user_affiliation_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id",  nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    private String organization;
+
+    private String department;
+
+    private String position;
+}

--- a/src/main/java/com/bmilab/backend/domain/user/enums/UserPosition.java
+++ b/src/main/java/com/bmilab/backend/domain/user/enums/UserPosition.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum UserAffiliation {
+public enum UserPosition {
     PROFESSOR("교수"),
     CO_PRINCIPAL_INVESTIGATOR("공동연구책임자"),
     POSTDOCTORAL_RESEARCHER("박사후 연구원"),

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserRepositoryCustomImpl.java
@@ -12,7 +12,7 @@ import com.bmilab.backend.domain.user.entity.QUserInfo;
 import com.bmilab.backend.domain.user.entity.QUserProjectCategory;
 import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.entity.UserInfo;
-import com.bmilab.backend.domain.user.enums.UserAffiliation;
+import com.bmilab.backend.domain.user.enums.UserPosition;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
@@ -73,9 +73,9 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
             switch (filterBy) {
                 case "name" -> conditionBuilder.and(user.name.containsIgnoreCase(filterValue));
                 case "email" -> conditionBuilder.and(user.email.containsIgnoreCase(filterValue));
-                case "department" -> conditionBuilder.and(user.department.containsIgnoreCase(filterValue));
                 case "organization" -> conditionBuilder.and(user.organization.containsIgnoreCase(filterValue));
-                case "affiliation" -> conditionBuilder.and(user.affiliation.eq(UserAffiliation.valueOf(filterValue.toUpperCase())));
+                case "department" -> conditionBuilder.and(user.department.containsIgnoreCase(filterValue));
+                case "position" -> conditionBuilder.and(user.position.eq(UserPosition.valueOf(filterValue.toUpperCase())));
                 case "projectname" -> conditionBuilder.and(category.name.containsIgnoreCase(filterValue));
                 case "seatnumber" -> conditionBuilder.and(userInfo.seatNumber.containsIgnoreCase(filterValue));
                 case "phonenumber" -> conditionBuilder.and(userInfo.phoneNumber.containsIgnoreCase(filterValue));

--- a/src/main/java/com/bmilab/backend/domain/user/repository/UserSubAffiliationRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/user/repository/UserSubAffiliationRepository.java
@@ -1,0 +1,11 @@
+package com.bmilab.backend.domain.user.repository;
+
+import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.domain.user.entity.UserSubAffiliation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserSubAffiliationRepository extends JpaRepository<UserSubAffiliation, Long> {
+    List<UserSubAffiliation> findAllByUser(User user);
+}

--- a/src/main/java/com/bmilab/backend/domain/user/service/AuthService.java
+++ b/src/main/java/com/bmilab/backend/domain/user/service/AuthService.java
@@ -53,7 +53,7 @@ public class AuthService {
                 .role(request.role())
                 .organization(request.organization())
                 .department(request.department())
-                .affiliation(request.affiliation())
+                .position(request.position())
                 .role(Role.USER)
                 .build();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #40 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- users 테이블 수정: 사용자 주 소속을 관리 기관, 부서, 구분
- user_sub_affiliations 테이블 생성: 서브 소속 정보(기관, 부서, 구분)를 관리하는 테이블을 추가


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
