### PR TITLE
feat: 이름 정규식에 영문 허용 및 유효성 검증 실패 시 한글 메시지 반환

### DIFF
--- a/src/main/java/com/bmilab/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/bmilab/backend/global/exception/ErrorResponse.java
@@ -50,7 +50,7 @@ public class ErrorResponse {
         return ErrorResponse
                 .builder()
                 .code(status.name())
-                .message(e.getMessage() != null ? e.getMessage() : "An unexpected error occurred")
+                .message(e.getMessage())
                 .status(status.value())
                 .timestamp(timestamp)
                 .build();

--- a/src/main/java/com/bmilab/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bmilab/backend/global/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -61,7 +62,21 @@ public class GlobalExceptionHandler {
     private ResponseEntity<ErrorResponse> handleValidationException(BindException exception) {
 
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        ErrorResponse errorResponse = ErrorResponse.from(exception, status, Instant.now());
+
+        String message = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .findFirst()
+                .orElse("입력값이 올바르지 않습니다.");
+
+        ErrorResponse errorResponse = ErrorResponse
+                .builder()
+                .code(status.name())
+                .message(message)
+                .status(status.value())
+                .timestamp(Instant.now())
+                .build();
 
         return ResponseEntity.status(status).body(errorResponse);
     }

--- a/src/main/java/com/bmilab/backend/global/validation/RegExp.java
+++ b/src/main/java/com/bmilab/backend/global/validation/RegExp.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RegExp {
 
-    public static final String NAME_EXPRESSION = "^[가-힣]{2,}$";
-    public static final String NAME_MESSAGE = "올바른 이름이 아닙니다.";
+    public static final String NAME_EXPRESSION = "^[가-힣a-zA-Z]{2,}$";
+    public static final String NAME_MESSAGE = "이름은 한글 또는 영문 2자 이상 입력해 주세요.";
 
     public static final String EMAIL_EXPRESSION = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String EMAIL_MESSAGE = "이메일 형식이 올바르지 않습니다.";


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #38 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 이름 입력값 검증에 영문자 허용 및 메시지 수정
- 유효성 검증 실패 시 한글 메시지만 반환하도록 예외 응답 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
