### PR TITLE
fix: 비밀번호 재발급 시 인증을 거치지 않도록 수정

### DIFF
--- a/src/main/java/com/bmilab/backend/global/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/bmilab/backend/global/jwt/TokenAuthenticationFilter.java
@@ -70,7 +70,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
 
-        String[] excludes = { "/auth/", "/swagger-ui", "/api-docs" };
+        String[] excludes = { "/auth/", "/swagger-ui", "/api-docs", "/users/password" };
         String path = request.getRequestURI();
 
         return Arrays.stream(excludes).anyMatch(path::startsWith);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 비밀번호 재발급 API 호출 시 토큰 인증 필터를 거쳐 401 에러가 나던 현상을 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
