### PR TITLE
feat: 휴가 API 응답 구조 수정

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/leave/controller/AdminLeaveApi.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/controller/AdminLeaveApi.java
@@ -1,12 +1,19 @@
 package com.bmilab.backend.domain.leave.controller;
 
 import com.bmilab.backend.domain.leave.dto.request.RejectLeaveRequest;
+import com.bmilab.backend.domain.leave.dto.response.LeaveFindAllResponse;
+import com.bmilab.backend.global.security.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Tag(name = "(Admin) Leave", description = "관리자용 휴가 API")
 public interface AdminLeaveApi {
@@ -23,7 +30,10 @@ public interface AdminLeaveApi {
                     )
             }
     )
-    ResponseEntity<Void> approveLeave(@PathVariable long leaveId);
+    ResponseEntity<Void> approveLeave(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            @PathVariable long leaveId
+    );
 
     @Operation(summary = "휴가 반려", description = "휴가 요청을 반려하는 POST API")
     @ApiResponses(
@@ -38,5 +48,23 @@ public interface AdminLeaveApi {
                     )
             }
     )
-    ResponseEntity<Void> rejectLeave(@PathVariable long leaveId, RejectLeaveRequest request);
+    ResponseEntity<Void> rejectLeave(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            @PathVariable long leaveId,
+            RejectLeaveRequest request
+    );
+
+    @Operation(summary = "(관리자) 전체 휴가 조회", description = "휴가 정보를 모두 조회하거나 기간별로 조회할 수 있는 GET API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "조회 성공"
+                    )
+            }
+    )
+    ResponseEntity<LeaveFindAllResponse> getLeaves(
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate
+    );
 }

--- a/src/main/java/com/bmilab/backend/domain/leave/controller/AdminLeaveController.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/controller/AdminLeaveController.java
@@ -1,16 +1,23 @@
 package com.bmilab.backend.domain.leave.controller;
 
 import com.bmilab.backend.domain.leave.dto.request.RejectLeaveRequest;
+import com.bmilab.backend.domain.leave.dto.response.LeaveFindAllResponse;
 import com.bmilab.backend.domain.leave.service.LeaveService;
 import com.bmilab.backend.global.annotation.OnlyAdmin;
+import com.bmilab.backend.global.security.UserAuthInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @OnlyAdmin
 @RestController
@@ -20,17 +27,29 @@ public class AdminLeaveController implements AdminLeaveApi {
     private final LeaveService leaveService;
 
     @PostMapping("/{leaveId}/approve")
-    public ResponseEntity<Void> approveLeave(@PathVariable long leaveId) {
-        leaveService.approveLeave(leaveId);
+    public ResponseEntity<Void> approveLeave(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
+            @PathVariable long leaveId
+    ) {
+        leaveService.approveLeave(userAuthInfo.getUserId(), leaveId);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{leaveId}/reject")
     public ResponseEntity<Void> rejectLeave(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo,
             @PathVariable long leaveId,
             @RequestBody @Valid RejectLeaveRequest request
     ) {
-        leaveService.rejectLeave(leaveId, request);
+        leaveService.rejectLeave(userAuthInfo.getUserId(), leaveId, request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<LeaveFindAllResponse> getLeaves(
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate
+    ) {
+        return ResponseEntity.ok(leaveService.getLeaves(startDate, endDate));
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/leave/controller/LeaveApi.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/controller/LeaveApi.java
@@ -2,12 +2,14 @@ package com.bmilab.backend.domain.leave.controller;
 
 import com.bmilab.backend.domain.leave.dto.request.ApplyLeaveRequest;
 import com.bmilab.backend.domain.leave.dto.response.LeaveFindAllResponse;
+import com.bmilab.backend.domain.leave.dto.response.UserLeaveResponse;
 import com.bmilab.backend.global.security.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDateTime;
+
+import java.time.LocalDate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,8 +26,8 @@ public interface LeaveApi {
             }
     )
     ResponseEntity<LeaveFindAllResponse> getLeaves(
-            @RequestParam(required = false) LocalDateTime startDate,
-            @RequestParam(required = false) LocalDateTime endDate
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate
     );
 
     @Operation(summary = "사용자 휴가 조회", description = "사용자의 휴가 정보를 조회하는 GET API")
@@ -37,7 +39,7 @@ public interface LeaveApi {
                     )
             }
     )
-    ResponseEntity<LeaveFindAllResponse> getLeavesByUser(
+    ResponseEntity<UserLeaveResponse> getLeavesByUser(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo
     );
 

--- a/src/main/java/com/bmilab/backend/domain/leave/controller/LeaveController.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/controller/LeaveController.java
@@ -2,6 +2,8 @@ package com.bmilab.backend.domain.leave.controller;
 
 import com.bmilab.backend.domain.leave.dto.request.ApplyLeaveRequest;
 import com.bmilab.backend.domain.leave.dto.response.LeaveFindAllResponse;
+import com.bmilab.backend.domain.leave.dto.response.UserLeaveResponse;
+import com.bmilab.backend.domain.leave.enums.LeaveStatus;
 import com.bmilab.backend.domain.leave.service.LeaveService;
 import com.bmilab.backend.global.security.UserAuthInfo;
 import jakarta.validation.Valid;
@@ -15,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/leaves")
@@ -25,14 +27,14 @@ public class LeaveController implements LeaveApi {
 
     @GetMapping
     public ResponseEntity<LeaveFindAllResponse> getLeaves(
-            @RequestParam(required = false) LocalDateTime startDate,
-            @RequestParam(required = false) LocalDateTime endDate
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate
     ) {
-        return ResponseEntity.ok(leaveService.getLeaves(startDate, endDate));
+        return ResponseEntity.ok(leaveService.getLeaves(startDate, endDate, LeaveStatus.APPROVED));
     }
 
     @GetMapping("/me")
-    public ResponseEntity<LeaveFindAllResponse> getLeavesByUser(
+    public ResponseEntity<UserLeaveResponse> getLeavesByUser(
             @AuthenticationPrincipal UserAuthInfo userAuthInfo
     ) {
         return ResponseEntity.ok(leaveService.getLeavesByUser(userAuthInfo.getUserId()));

--- a/src/main/java/com/bmilab/backend/domain/leave/dto/request/ApplyLeaveRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/dto/request/ApplyLeaveRequest.java
@@ -6,20 +6,20 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record ApplyLeaveRequest(
-        @Schema(description = "휴가 시작 일시", example = "2025-05-01T09:00:00")
-        @NotNull(message = "휴가 시작 일시는 필수입니다.")
-        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime startDate,
+        @Schema(description = "휴가 시작일")
+        @NotNull(message = "휴가 시작일은 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
 
-        @Schema(description = "휴가 종료 일시", example = "2025-05-02T18:00:00")
-        @NotNull(message = "휴가 종료 일시는 필수입니다.")
-        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime endDate,
+        @Schema(description = "휴가 종료일")
+        @NotNull(message = "휴가 종료일은 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
 
-        @Schema(description = "휴가 종류 (예: ANNUAL, SICK, HALF)", example = "ANNUAL")
+        @Schema(description = "휴가 종류", example = "ANNUAL")
         @NotNull(message = "휴가 종류는 필수입니다.")
         LeaveType type,
 

--- a/src/main/java/com/bmilab/backend/domain/leave/dto/response/LeaveDetail.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/dto/response/LeaveDetail.java
@@ -5,6 +5,8 @@ import com.bmilab.backend.domain.leave.enums.LeaveStatus;
 import com.bmilab.backend.domain.leave.enums.LeaveType;
 import com.bmilab.backend.domain.user.dto.response.UserSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
@@ -16,11 +18,11 @@ public record LeaveDetail(
         @Schema(description = "사용자 정보")
         UserSummary user,
 
-        @Schema(description = "휴가 시작 일시", example = "2025-05-01T09:00:00")
-        LocalDateTime startDate,
+        @Schema(description = "휴가 시작 일시")
+        LocalDate startDate,
 
-        @Schema(description = "휴가 종료 일시", example = "2025-05-02T18:00:00")
-        LocalDateTime endDate,
+        @Schema(description = "휴가 종료 일시")
+        LocalDate endDate,
 
         @Schema(description = "휴가 승인 상태", example = "APPROVED")
         LeaveStatus status,
@@ -33,6 +35,12 @@ public record LeaveDetail(
 
         @Schema(description = "반려 사유 (있을 경우)", example = "업무 공백 우려로 인해 반려됨")
         String rejectReason,
+
+        @Schema(description = "휴가 처리자 정보")
+        UserSummary processor,
+
+        @Schema(description = "처리 일시", example = "2025-04-23T15:30:00")
+        LocalDateTime processedAt,
 
         @Schema(description = "신청 일시", example = "2025-04-23T15:30:00")
         LocalDateTime applicatedAt
@@ -48,6 +56,8 @@ public record LeaveDetail(
                 .type(leave.getType())
                 .reason(leave.getReason())
                 .rejectReason(leave.getRejectReason())
+                .processor(leave.getProcessor() == null ? null : UserSummary.from(leave.getProcessor()))
+                .processedAt(leave.getProcessedAt())
                 .applicatedAt(leave.getApplicatedAt())
                 .build();
     }

--- a/src/main/java/com/bmilab/backend/domain/leave/dto/response/UserLeaveResponse.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/dto/response/UserLeaveResponse.java
@@ -1,0 +1,29 @@
+package com.bmilab.backend.domain.leave.dto.response;
+
+import com.bmilab.backend.domain.leave.entity.Leave;
+import com.bmilab.backend.domain.leave.entity.UserLeave;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record UserLeaveResponse(
+        @Schema(description = "총 연차 수", example = "15.0")
+        Double annualLeaveCount,
+
+        @Schema(description = "사용한 연차 수", example = "3.5")
+        Double usedLeaveCount,
+
+        List<LeaveDetail> leaves
+) {
+
+    public static UserLeaveResponse of(UserLeave userLeave, List<Leave> leaves) {
+
+        return new UserLeaveResponse(
+                userLeave.getAnnualLeaveCount(),
+                userLeave.getUsedLeaveCount(),
+                leaves.stream()
+                        .map(LeaveDetail::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/bmilab/backend/domain/leave/entity/Leave.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/entity/Leave.java
@@ -43,11 +43,16 @@ public class Leave extends BaseTimeEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
+    @ManyToOne
+    @JoinColumn(name = "processor_id")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private User processor;
+
     @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Column(name = "end_date")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @Enumerated(EnumType.ORDINAL)
     @Column(name = "leave_status", nullable = false)
@@ -66,17 +71,24 @@ public class Leave extends BaseTimeEntity {
     @Column(name = "leave_count")
     private Double leaveCount;
 
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
     @CreatedDate
     @Column(name = "applicated_at", nullable = false)
     private LocalDateTime applicatedAt;
 
-    public void approve() {
+    public void approve(User processor, LocalDateTime now) {
         status = LeaveStatus.APPROVED;
+        this.processor = processor;
+        processedAt = now;
     }
 
-    public void reject(String rejectReason) {
+    public void reject(String rejectReason, User processor, LocalDateTime now) {
         status = LeaveStatus.REJECTED;
         this.rejectReason = rejectReason;
+        this.processor = processor;
+        processedAt = now;
     }
 
     public boolean isNotPending() {
@@ -100,8 +112,8 @@ public class Leave extends BaseTimeEntity {
         LocalDate lastDayOfMonth = yearMonth.atEndOfMonth();
 
         // 실제 비교할 시작일과 종료일 설정
-        LocalDate effectiveStart = startDate.isBefore(firstDayOfMonth.atStartOfDay()) ? firstDayOfMonth : startDate.toLocalDate();
-        LocalDate effectiveEnd = endDate.isAfter(lastDayOfMonth.atStartOfDay()) ? lastDayOfMonth : endDate.toLocalDate();
+        LocalDate effectiveStart = startDate.isBefore(firstDayOfMonth) ? firstDayOfMonth : startDate;
+        LocalDate effectiveEnd = endDate.isAfter(lastDayOfMonth) ? lastDayOfMonth : endDate;
 
         // 포함되는 날짜 수 계산
         return effectiveStart.isAfter(effectiveEnd) ? 0 : (int) (effectiveStart.datesUntil(effectiveEnd.plusDays(1)).count());

--- a/src/main/java/com/bmilab/backend/domain/leave/enums/LeaveType.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/enums/LeaveType.java
@@ -4,7 +4,13 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum LeaveType {
-    ANNUAL("연가"), SICK("병가"), HALF("반차"), ETC("기타");
+    ANNUAL("연차"),
+    HALF_AM("오전 반차"),
+    HALF_PM("오후 반차"),
+    SPECIAL_HALF_AM("특별 오전 반차"),
+    SPECIAL_HALF_PM("특별 오후 반차"),
+    SPECIAL_ANNUAL("특별 연차")
+    ;
 
     private String description;
 }

--- a/src/main/java/com/bmilab/backend/domain/leave/enums/LeaveType.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/enums/LeaveType.java
@@ -13,4 +13,8 @@ public enum LeaveType {
     ;
 
     private String description;
+
+    public boolean isHalf() {
+        return this == HALF_AM || this == HALF_PM;
+    }
 }

--- a/src/main/java/com/bmilab/backend/domain/leave/repository/LeaveRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/repository/LeaveRepository.java
@@ -1,8 +1,13 @@
 package com.bmilab.backend.domain.leave.repository;
 
 import com.bmilab.backend.domain.leave.entity.Leave;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.bmilab.backend.domain.leave.enums.LeaveStatus;
+import com.bmilab.backend.domain.leave.enums.LeaveType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,7 +15,14 @@ public interface LeaveRepository extends JpaRepository<Leave, Long> {
     @Query("SELECT l FROM Leave l"
             + " WHERE (l.startDate BETWEEN :start AND :end)"
             + " OR(l.endDate BETWEEN  :start AND :end)")
-    List<Leave> findAllByBetweenDates(LocalDateTime start, LocalDateTime end);
+    List<Leave> findAllByBetweenDates(LocalDate start, LocalDate end);
+
+    @Query("SELECT l FROM Leave l"
+            + " WHERE ((l.startDate BETWEEN :start AND :end) OR (l.endDate BETWEEN  :start AND :end))"
+            + " AND l.status = :status")
+    List<Leave> findAllByBetweenDatesAndStatus(LocalDate start, LocalDate end, LeaveStatus status);
 
     List<Leave> findAllByUserId(Long userId);
+
+    List<Leave> findAllByStatus(LeaveStatus status);
 }

--- a/src/main/java/com/bmilab/backend/domain/leave/service/LeaveSchedulerService.java
+++ b/src/main/java/com/bmilab/backend/domain/leave/service/LeaveSchedulerService.java
@@ -22,7 +22,6 @@ import org.springframework.web.client.RestClient;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class LeaveSchedulerService {
     private final LeaveService leaveService;
     @Value("${data-portal.service-key}")
@@ -34,12 +33,12 @@ public class LeaveSchedulerService {
     @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
     @Transactional
     public void updateUserAnnualLeaves() {
-        if (YearMonth.from(LocalDate.now()).getYear() == 2025) {
-            log.info("임시 중단");
+        YearMonth lastMonthWithYear = YearMonth.now().minusMonths(1);
+
+        if (lastMonthWithYear.getYear() == 2025) {
             return;
         }
 
-        YearMonth lastMonthWithYear = YearMonth.now().minusMonths(1);
         int endOfMonth = lastMonthWithYear.lengthOfMonth();
         int holidayCount = countHolidays(lastMonthWithYear);
         int weekendCount = (int) countWeekends(lastMonthWithYear);
@@ -72,7 +71,7 @@ public class LeaveSchedulerService {
                         leaveIncrement += 1;
                     }
 
-                    if (((weekdayCount * 2) / 3) <= workedCount) {
+                    if (((weekdayCount * 4) / 5) <= workedCount) {
                         log.info("[user={}] Worked", userId);
                         leaveIncrement += 1;
                     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#83 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 휴가 API의 응답 구조를 수정했습니다.
2. 휴가 엔티티에 처리일, 처리자 정보를 추가했습니다.
3. 휴가 타입 enum의 내용을 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

머지할 때 DB에서 leaves 테이블을 삭제한 후에 머지해주세요~
