### PR TITLE
feat: 프로젝트 고정글 개수 제한 및 비관적 락을 통한 동시성 처리

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/project/exception/ProjectErrorCode.java
+++ b/src/main/java/com/bmilab/backend/domain/project/exception/ProjectErrorCode.java
@@ -16,7 +16,9 @@ public enum ProjectErrorCode implements ErrorCode {
     EXTERNAL_PROFESSOR_NOT_FOUND("외부 교수 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     EXTERNAL_PROFESSOR_DUPLICATE("외부 교수 정보가 이미 존재합니다.", HttpStatus.CONFLICT),
     IRB_FILES_IS_EMPTY("IRB 파일이 없습니다.", HttpStatus.NOT_FOUND),
-    DRB_FILES_IS_EMPTY("DRB 파일이 없습니다.", HttpStatus.NOT_FOUND)
+    DRB_FILES_IS_EMPTY("DRB 파일이 없습니다.", HttpStatus.NOT_FOUND),
+    PROJECT_PIN_LIMIT_EXCEEDED("고정글은 최대 5개까지만 설정할 수 있습니다.",  HttpStatus.BAD_REQUEST),
+    PROJECT_PIN_VERSION_CONFLICT("동시에 다른 관리자가 연구를 수정하여 충돌이 발생했습니다. 다시 시도해주세요.", HttpStatus.CONFLICT);
     ;
 
     private final String message;

--- a/src/main/java/com/bmilab/backend/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/project/repository/ProjectRepository.java
@@ -1,7 +1,21 @@
 package com.bmilab.backend.domain.project.repository;
 
 import com.bmilab.backend.domain.project.entity.Project;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Project p WHERE p.id = :projectId")
+    Optional<Project> findByIdWithPessimisticLock(@Param("projectId") Long projectId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Project p WHERE p.isPinned = true ORDER BY p.id ASC")
+    List<Project> findAllPinnedForUpdate();
 }

--- a/src/test/java/com/bmilab/backend/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/bmilab/backend/domain/project/service/ProjectServiceTest.java
@@ -1,0 +1,255 @@
+package com.bmilab.backend.domain.project.service;
+
+import com.bmilab.backend.domain.file.service.FileService;
+import com.bmilab.backend.domain.project.dto.request.ProjectPinRequest;
+import com.bmilab.backend.domain.project.entity.Project;
+import com.bmilab.backend.domain.project.enums.ProjectStatus;
+import com.bmilab.backend.domain.project.exception.ProjectErrorCode;
+import com.bmilab.backend.domain.project.repository.ProjectRepository;
+import com.bmilab.backend.domain.projectcategory.entity.ProjectCategory;
+import com.bmilab.backend.domain.projectcategory.service.ProjectCategoryService;
+import com.bmilab.backend.domain.user.entity.User;
+import com.bmilab.backend.domain.user.service.UserService;
+import com.bmilab.backend.global.exception.ApiException;
+import com.bmilab.backend.global.external.s3.S3Service;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ProjectService updateProjectPinStatus 동시성 및 락 동작을 검증하는 테스트 클래스
+ *
+ * 전제 조건:
+ * - ActiveProfile이 local이어야 함
+ * - 로컬 DB(MySQL 등)에 id=1인 User, id=1인 ProjectCategory 데이터가 있어야 함
+ * - 이 데이터가 없으면 FK 제약으로 인해 테스트 실패
+ */
+@DataJpaTest
+@ActiveProfiles("local")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ ProjectService.class, com.bmilab.backend.domain.project.service.ProjectServiceTest.StubBeans.class})
+class ProjectServiceTest {
+
+    @Autowired ProjectService projectService;
+    @Autowired ProjectRepository projectRepository;
+    @Autowired EntityManager em;
+    @Autowired PlatformTransactionManager txManager;
+
+    /**
+     * QueryDSL 사용을 위한 JPAQueryFactory 빈 설정
+     */
+    @TestConfiguration
+    static class TestJpaConfig {
+        @Bean JPAQueryFactory jpaQueryFactory(EntityManager em) {
+            return new JPAQueryFactory(em);
+        }
+    }
+
+    /**
+     * 테스트 시 실제 서비스 의존성을 모두 Mock으로 대체
+     * - UserService, ProjectCategoryService, FileService, S3Service
+     */
+    @TestConfiguration
+    static class StubBeans {
+        @Bean UserService userService() { return Mockito.mock(UserService.class); }
+        @Bean
+        ProjectCategoryService projectCategoryService() { return Mockito.mock(ProjectCategoryService.class); }
+        @Bean FileService fileService() { return Mockito.mock(FileService.class); }
+        @Bean S3Service s3Service() { return Mockito.mock(S3Service.class); }
+    }
+
+    /**
+     * 각 테스트 시작 전 Project 테이블 데이터를 비워 테스트 간 간섭을 방지
+     */
+    @BeforeEach
+    void clean() {
+        projectRepository.deleteAll();
+    }
+
+    /**
+     * 트랜잭션 안에서 주어진 작업을 실행하기 위한 유틸 메서드
+     * (FOR UPDATE 쿼리 같은 트랜잭션 내에서만 가능한 검증 로직 실행 시 사용)
+     */
+    private <T> T inTx(Supplier<T> work) {
+        return new TransactionTemplate(txManager).execute(status -> work.get());
+    }
+
+    /**
+     * 새 프로젝트(Project) 엔티티를 생성하고 저장
+     *
+     * 주의: 로컬 DB에 id=1 User, id=1 ProjectCategory가 있어야 함
+     */
+    private Project newProject(String title, boolean pinned) {
+        User authorRef = em.getReference(User.class, 1L); // 기존 로컬 DB User 참조
+        ProjectCategory categoryRef = em.getReference(ProjectCategory.class, 1L); // 기존 로컬 DB 카테고리 참조
+
+        Project b = Project.builder()
+                .title(title)
+                .content("test")
+                .isPinned(pinned)
+                .author(authorRef)
+                .category(categoryRef)
+                .startDate(java.time.LocalDate.now())
+                .status(ProjectStatus.IN_PROGRESS)
+                .build();
+        return projectRepository.save(b);
+    }
+
+    /**
+     * 시나리오:
+     * - 이미 4개의 프로젝트가 고정된 상태에서
+     * - 두 명의 관리자가 동시에 서로 다른 프로젝트를 고정하려고 시도
+     *
+     * 기대:
+     * - 둘 중 하나만 성공, 다른 하나는 BOARD_PIN_LIMIT_EXCEEDED 에러
+     * - 최종 고정 개수는 5개 유지
+     *
+     * @Transactional(propagation = NOT_SUPPORTED) :
+     *   테스트 메서드 자체 트랜잭션을 끄고, 서비스 메서드 트랜잭션과 완전히 분리
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Test
+    void pinLimit_concurrentPins_onlyOneSucceeds_whenAlready4Pinned() throws InterruptedException {
+        // given: 이미 4개가 고정된 상태
+        for (int i = 0; i < 4; i++) {
+            newProject("pinned-" + i, true);
+        }
+        Project c1 = newProject("candidate-1", false);
+        Project c2 = newProject("candidate-2", false);
+
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService es = Executors.newFixedThreadPool(2);
+        List<Future<String>> results = new ArrayList<>();
+
+        // 첫 번째 스레드: c1 프로젝트 고정 시도
+        Callable<String> t1 = () -> {
+            start.await();
+            try {
+                projectService.updateProjectPinStatus(c1.getId(), new ProjectPinRequest(true));
+                return "OK";
+            } catch (ApiException ex) {
+                return ex.getErrorCode().name();
+            }
+        };
+
+        // 두 번째 스레드: c2 프로젝트 고정 시도
+        // ApiException 발생 시 해당 에러 코드 이름 반환
+        Callable<String> t2 = () -> {
+            start.await();
+            try {
+                projectService.updateProjectPinStatus(c2.getId(), new ProjectPinRequest(true));
+                return "OK";
+            } catch (ApiException ex) {
+                return ex.getErrorCode().name();
+            }
+        };
+
+        results.add(es.submit(t1));
+        results.add(es.submit(t2));
+
+        // when: 두 스레드 동시 시작
+        start.countDown();
+        es.shutdown();
+        boolean done = es.awaitTermination(10, TimeUnit.SECONDS);
+        assertThat(done).isTrue();
+
+        // then: 둘 중 하나만 성공해야 함
+        String r1 = get(results.get(0));
+        String r2 = get(results.get(1));
+        assertThat(List.of(r1, r2))
+                .containsExactlyInAnyOrder("OK", ProjectErrorCode.PROJECT_PIN_LIMIT_EXCEEDED.name());
+
+        // 최종 고정 개수는 5개여야 함
+        long pinnedCount = inTx(() -> projectRepository.findAllPinnedForUpdate().size());
+        assertThat(pinnedCount).isEqualTo(5);
+    }
+
+    /**
+     * 시나리오:
+     * - 하나의 프로젝트에 대해 동시에 PIN, UNPIN 요청 발생
+     *
+     * 기대:
+     * - 요청이 직렬화되어 실행되어야 함
+     * - 마지막으로 완료된 작업 상태와 실제 DB 상태가 일치해야 함
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Test
+    void samePost_concurrentPinAndUnpin_areSerialized_noLostUpdate() throws InterruptedException, ExecutionException {
+        // given: 초기 상태는 UNPIN
+        Project target = newProject("target", false);
+
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService es = Executors.newFixedThreadPool(2);
+        java.util.concurrent.ConcurrentLinkedQueue<String> order = new java.util.concurrent.ConcurrentLinkedQueue<>();
+
+        // 핀 작업
+        Callable<Void> pinTask = () -> {
+            start.await();
+            projectService.updateProjectPinStatus(target.getId(), new ProjectPinRequest(true));
+            order.add("PIN");
+            return null;
+        };
+
+        // 언핀 작업
+        Callable<Void> unpinTask = () -> {
+            start.await();
+            projectService.updateProjectPinStatus(target.getId(), new ProjectPinRequest(false));
+            order.add("UNPIN");
+            return null;
+        };
+
+        Future<Void> f1 = es.submit(pinTask);
+        Future<Void> f2 = es.submit(unpinTask);
+
+        // when
+        start.countDown();
+        f1.get();
+        f2.get();
+        es.shutdown();
+
+        // then: 예외 없이 직렬화 처리, 마지막 작업 결과와 DB 상태 일치
+        Project reloaded = inTx(() -> projectRepository.findByIdWithPessimisticLock(target.getId()).orElseThrow());
+        String lastDone = null;
+        for (String s : order) lastDone = s; // 마지막으로 완료된 작업
+        assertThat(lastDone).isIn("PIN", "UNPIN");
+        if ("PIN".equals(lastDone)) {
+            assertThat(reloaded.isPinned()).isTrue();
+        } else {
+            assertThat(reloaded.isPinned()).isFalse();
+        }
+    }
+
+    /**
+     * Future 결과를 안전하게 가져오기 위한 유틸
+     */
+    private static <T> T get(Future<T> f) {
+        try { return f.get(); }
+        catch (Exception e) { throw new RuntimeException(e); }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #86 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 프로젝트 고정글 개수 최대 5개로 제한
- 비관적 락 기반 동시성 처리 적용
- 동시 요청 데드락 방지: 핀 목록 FOR UPDATE에 ORDER BY 적용(락 순서 고정) + 재시도(REQUIRES_NEW) 로직 도입
- 테스트 코드 작성
    - 4개 고정 상태에서 서로 다른 연구를 동시에 고정 시도 → 한쪽만 성공, 다른 한쪽은 제한 에러
    - 단일 연구에 대해 동시 PIN/UNPIN 요청 → 직렬화 보장 및 최종 상태 일치 검증

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
