### PR TITLE
feat: 업무보고 엑셀 다운로드/메일 전송 구현

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportApi.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -27,5 +28,18 @@ public interface AdminReportApi {
             @RequestParam(required = false) LocalDate startDate,
             @RequestParam(required = false) LocalDate endDate,
             @RequestParam(required = false) String keyword
+    );
+
+    @Operation(summary = "일별 보고 엑셀파일 다운로드", description = "일별로 업무보고 엑셀파일을 다운로드할 수 있는 GET API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "파일 다운로드 성공"
+                    ),
+            }
+    )
+    ResponseEntity<InputStreamResource> createReportExcel(
+            @RequestParam LocalDate date
     );
 }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportController.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/AdminReportController.java
@@ -2,13 +2,19 @@ package com.bmilab.backend.domain.report.controller;
 
 import com.bmilab.backend.domain.report.dto.response.ReportFindAllResponse;
 import com.bmilab.backend.domain.report.service.ReportService;
+import com.bmilab.backend.global.utils.ExcelGenerator;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 import java.time.LocalDate;
 
 @RestController
@@ -34,5 +40,19 @@ public class AdminReportController implements AdminReportApi{
                 endDate,
                 keyword
         ));
+    }
+
+    @GetMapping("/excel")
+    public ResponseEntity<InputStreamResource> createReportExcel(
+            @RequestParam LocalDate date
+    ) {
+
+        ByteArrayInputStream excel = reportService.getReportExcelFileByDateAsBytes(date);
+        MediaType excelMediaType = MediaType.valueOf(ExcelGenerator.EXCEL_MEDIA_TYPE);
+
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=report_" + date + ".xlsx")
+                .contentType(excelMediaType)
+                .body(new InputStreamResource(excel));
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/ReportApi.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/ReportApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -74,5 +75,18 @@ public interface ReportApi {
             @RequestParam(required = false) Long projectId,
             @RequestParam(required = false) LocalDate startDate,
             @RequestParam(required = false) LocalDate endDate
+    );
+
+    @Operation(summary = "내 업무보고 엑셀파일 다운로드", description = "현재 로그인한 사용자의 업무보고 목록을 엑셀파일로 다운로드할 수 있는 GET API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "파일 다운로드 성공"
+                    ),
+            }
+    )
+    ResponseEntity<InputStreamResource> getExcelFileByCurrentUser(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo
     );
 }

--- a/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/bmilab/backend/domain/report/controller/ReportController.java
@@ -4,8 +4,11 @@ import com.bmilab.backend.domain.report.dto.request.ReportRequest;
 import com.bmilab.backend.domain.report.dto.response.ReportFindAllResponse;
 import com.bmilab.backend.domain.report.service.ReportService;
 import com.bmilab.backend.global.security.UserAuthInfo;
+import com.bmilab.backend.global.utils.ExcelGenerator;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.ByteArrayInputStream;
 import java.time.LocalDate;
 
 @RestController
@@ -72,5 +76,19 @@ public class ReportController implements ReportApi {
                 startDate,
                 endDate
         ));
+    }
+
+    @GetMapping("/excel")
+    public ResponseEntity<InputStreamResource> getExcelFileByCurrentUser(
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo
+    ) {
+
+        ByteArrayInputStream excel = reportService.getReportExcelFileByUserAsBytes(userAuthInfo.getUserId());
+        MediaType excelMediaType = MediaType.valueOf(ExcelGenerator.EXCEL_MEDIA_TYPE);
+
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=report_" + userAuthInfo.getUserId() + ".xlsx")
+                .contentType(excelMediaType)
+                .body(new InputStreamResource(excel));
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepository.java
@@ -3,6 +3,8 @@ package com.bmilab.backend.domain.report.repository;
 import com.bmilab.backend.domain.report.entity.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReportRepository extends JpaRepository<Report, Long>, ReportRepositoryCustom {
+import java.time.LocalDate;
+import java.util.List;
 
+public interface ReportRepository extends JpaRepository<Report, Long>, ReportRepositoryCustom {
 }

--- a/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/com/bmilab/backend/domain/report/repository/ReportRepositoryCustom.java
@@ -21,4 +21,8 @@ public interface ReportRepositoryCustom {
             LocalDate endDate,
             String keyword
     );
+
+    List<GetAllReportsQueryResult> findAllByDateWithFiles(LocalDate date);
+
+    List<GetAllReportsQueryResult> findAllByUser(Long userId);
 }

--- a/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
@@ -15,10 +15,15 @@ import com.bmilab.backend.domain.report.repository.ReportRepository;
 import com.bmilab.backend.domain.user.entity.User;
 import com.bmilab.backend.domain.user.service.UserService;
 import com.bmilab.backend.global.exception.ApiException;
+import com.bmilab.backend.global.utils.ExcelGenerator;
+import com.bmilab.backend.global.utils.ExcelRow;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -32,6 +37,7 @@ public class ReportService {
     private final FileInformationRepository fileInformationRepository;
     private final FileService fileService;
     private final ProjectService projectService;
+    private final ExcelGenerator excelGenerator;
 
     public Report findReportById(Long reportId) {
 
@@ -132,10 +138,82 @@ public class ReportService {
         reportRepository.delete(report);
     }
 
+    public ByteArrayInputStream getReportExcelFileByDateAsBytes(LocalDate date) {
+
+        List<GetAllReportsQueryResult> results = reportRepository.findAllByDateWithFiles(date);
+        String[] headerTitles = { "이름", "연구 제목", "보고 내용", "첨부파일 URL" };
+
+        List<ExcelRow> excelRows = results.stream().map((result) -> {
+            Report report = result.report();
+            List<FileInformation> files = result.files();
+            String projectTitle = report.getProject().getTitle();
+            String userName = report.getUser().getName();
+            String content = report.getContent();
+            List<String> fileUrls = files.stream().map(FileInformation::getUploadUrl).toList();
+
+            return ExcelRow.of(userName, projectTitle, content, String.join("\n", fileUrls));
+        }).toList();
+
+        try {
+            return excelGenerator.generateBy(headerTitles, excelRows);
+        } catch(IOException e) {
+            e.printStackTrace();
+            throw new ApiException(e);
+        }
+    }
+
+    public File getReportExcelFileByDateAsFile(LocalDate date) {
+
+        List<GetAllReportsQueryResult> results = reportRepository.findAllByDateWithFiles(date);
+        String[] headerTitles = { "이름", "연구 제목", "보고 내용", "첨부파일 URL" };
+
+        List<ExcelRow> excelRows = results.stream().map((result) -> {
+            Report report = result.report();
+            List<FileInformation> files = result.files();
+            String projectTitle = report.getProject().getTitle();
+            String userName = report.getUser().getName();
+            String content = report.getContent();
+            List<String> fileUrls = files.stream().map(FileInformation::getUploadUrl).toList();
+
+            return ExcelRow.of(userName, projectTitle, content, String.join("\n", fileUrls));
+        }).toList();
+
+        try {
+            return excelGenerator.generateExcelFile(headerTitles, excelRows, "일일업무보고_" + date + ".xlsx");
+        } catch(Exception e) {
+            e.printStackTrace();
+            throw new ApiException(e);
+        }
+    }
+
     private void validateUserIsReportAuthor(User user, Report report) {
 
         if (!report.isAuthor(user)) {
             throw new ApiException(ReportErrorCode.REPORT_ACCESS_DENIED);
+        }
+    }
+
+    public ByteArrayInputStream getReportExcelFileByUserAsBytes(Long userId) {
+
+        List<GetAllReportsQueryResult> results = reportRepository.findAllByUser(userId);
+        String[] headerTitles = { "일자", "연구 제목", "보고 내용", "첨부파일 URL" };
+
+        List<ExcelRow> excelRows = results.stream().map((result) -> {
+            Report report = result.report();
+            List<FileInformation> files = result.files();
+            String projectTitle = report.getProject().getTitle();
+            String date = report.getDate().toString();
+            String content = report.getContent();
+            List<String> fileUrls = files.stream().map(FileInformation::getUploadUrl).toList();
+
+            return ExcelRow.of(date, projectTitle, content, String.join("\n", fileUrls));
+        }).toList();
+
+        try {
+            return excelGenerator.generateBy(headerTitles, excelRows);
+        } catch(IOException e) {
+            e.printStackTrace();
+            throw new ApiException(e);
         }
     }
 }

--- a/src/main/java/com/bmilab/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/bmilab/backend/domain/user/service/UserService.java
@@ -337,7 +337,7 @@ public class UserService {
 
         user.updatePassword(passwordEncoder.encode(newPassword));
 
-        emailSender.sendFindPasswordEmailAync(email, user.getName(), newPassword);
+        emailSender.sendFindPasswordEmailAsync(email, user.getName(), newPassword);
     }
 
     public void validateEmailDuplicate(String email) {

--- a/src/main/java/com/bmilab/backend/global/utils/ExcelGenerator.java
+++ b/src/main/java/com/bmilab/backend/global/utils/ExcelGenerator.java
@@ -1,0 +1,94 @@
+package com.bmilab.backend.global.utils;
+
+import lombok.val;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.xssf.streaming.SXSSFCell;
+import org.apache.poi.xssf.streaming.SXSSFRow;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class ExcelGenerator {
+    private static final int HEADER_ROW = 0;
+    public static final String EXCEL_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    public ByteArrayInputStream generateBy(String[] headerTitles, List<ExcelRow> rows) throws IOException {
+        SXSSFWorkbook workbook = generateWorkbook(headerTitles, rows);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        workbook.write(outputStream);
+        workbook.close();
+
+        return new ByteArrayInputStream(outputStream.toByteArray());
+    }
+
+    public File generateExcelFile(String[] headerTitles, List<ExcelRow> rows, String fileName) throws IOException {
+        SXSSFWorkbook workbook = generateWorkbook(headerTitles, rows);
+        File tempFile = new File(System.getProperty("java.io.tmpdir"), fileName);
+
+        try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+            workbook.write(outputStream);
+        }
+
+        workbook.close();
+
+        return tempFile;
+    }
+
+    private SXSSFWorkbook generateWorkbook(String[] headerTitles, List<ExcelRow> rows) {
+        SXSSFWorkbook workbook = new SXSSFWorkbook();
+        SXSSFSheet sheet = workbook.createSheet();
+
+        resizeSheetWidth(sheet);
+        styleHeaders(workbook, sheet, headerTitles);
+        fillData(sheet, rows);
+
+        return workbook;
+    }
+
+    private void styleHeaders(SXSSFWorkbook workbook, SXSSFSheet sheet, String[] headerTitles) {
+        Font headerFont = workbook.createFont();
+        headerFont.setBold(true);
+
+        CellStyle headerCellStyle = workbook.createCellStyle();
+        headerCellStyle.setFont(headerFont);
+        headerCellStyle.setFillForegroundColor(IndexedColors.GREY_80_PERCENT.getIndex());
+
+        SXSSFRow headerRow = sheet.createRow(HEADER_ROW);
+
+        for (int i = 0; i < headerTitles.length; i++) {
+            SXSSFCell cell = headerRow.createCell(i);
+
+            cell.setCellValue(headerTitles[i]);
+            cell.setCellStyle(headerCellStyle);
+        }
+    }
+
+    private void resizeSheetWidth(SXSSFSheet sheet) {
+        sheet.setColumnWidth(0, 256 * 10);
+        sheet.setColumnWidth(1, 256 * 50);
+        sheet.setColumnWidth(2, 256 * 100);
+        sheet.setColumnWidth(3, 256 * 100);
+    }
+
+    private void fillData(SXSSFSheet sheet, List<ExcelRow> rows) {
+        for (int i = 0; i < rows.size(); i++) {
+            SXSSFRow row = sheet.createRow(i + 1);
+            List<String> properties = rows.get(i).data();
+
+            for (int j = 0; j < properties.size(); j++) {
+                row.createCell(j).setCellValue(properties.get(j));
+            }
+        }
+    }
+}

--- a/src/main/java/com/bmilab/backend/global/utils/ExcelRow.java
+++ b/src/main/java/com/bmilab/backend/global/utils/ExcelRow.java
@@ -1,0 +1,11 @@
+package com.bmilab.backend.global.utils;
+
+import java.util.List;
+
+public record ExcelRow(
+        List<String> data
+) {
+    public static ExcelRow of(String... data) {
+        return new ExcelRow(List.of(data));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -57,3 +57,6 @@ sentry:
   dsn: ${SENTRY_DSN}
   send-default-pii: true
   environment: ${profile}
+
+service:
+  professor-mail-address: ${SERVICE_PROFESSOR_MAIL_ADDRESS}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -57,3 +57,6 @@ sentry:
   dsn: ${SENTRY_DSN}
   send-default-pii: true
   environment: ${profile}
+
+service:
+  professor-mail-address: ${SERVICE_PROFESSOR_MAIL_ADDRESS}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#85 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 업무보고 목록을 엑셀 파일로 다운로드할 수 있도록 구현했습니다.
2. 매일 오전 9시에 교수님 메일로 전날 업무보고 목록 엑셀파일이 메일로 발송되도록 구현하였습니다.
- 개발 서버 테스트를 위해 전송시각을 임시로 20시 20분으로 설정해두었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
