### PR TITLE
feat: 파일 업로드 구조 리팩터링 및 게시판 이미지 처리 추가

### DIFF
--- a/src/main/java/com/bmilab/backend/domain/board/dto/request/BoardRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/board/dto/request/BoardRequest.java
@@ -23,6 +23,10 @@ public record BoardRequest (
 
         @Schema(description  = "일반 첨부파일 ID 리스트", example = "[\"dfaef-afaefaef-aefaefae-...\", \"dfaef-afaefaef-aefaefae-..., dfaef-afaefaef-aefaefae-...\"]")
         @Nullable
-        List<UUID> fileIds
+        List<UUID> fileIds,
+
+        @Schema(description  = "내용 이미지 파일 ID 리스트", example = "[\"dfaef-afaefaef-aefaefae-...\", \"dfaef-afaefaef-aefaefae-..., dfaef-afaefaef-aefaefae-...\"]")
+        @Nullable
+        List<UUID> imageFileIds
 ){
 }

--- a/src/main/java/com/bmilab/backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/bmilab/backend/domain/board/service/BoardService.java
@@ -88,25 +88,8 @@ public class BoardService {
         );
 
         //신규 파일만 인식하기 + 이미지 업데이트 처리
-        updateBoardImageFiles(boardId, request.imageFileIds());
+        fileService.syncFiles(request.fileIds(), FileDomainType.BOARD, board.getId());
         fileService.updateAllFileDomainByIds(request.fileIds(), FileDomainType.BOARD, board.getId());
-    }
-
-    private void updateBoardImageFiles(Long boardId, List<UUID> imageFileIds) {
-        List<FileInformation> requestImageFiles = fileService.findAllById(imageFileIds);
-        List<FileInformation> boardImageFiles = fileService.findAllByDomainTypeAndEntityId(FileDomainType.BOARD_IMAGE,
-                boardId);
-
-        List<FileInformation> newBoardImageFiles = requestImageFiles.stream()
-                .filter(file -> !boardImageFiles.contains(file))
-                .toList();
-
-        List<FileInformation> deletedImageFiles = boardImageFiles.stream()
-                .filter(file -> !requestImageFiles.contains(file))
-                .toList();
-
-        newBoardImageFiles.forEach(file -> fileService.updateFileDomain(file, FileDomainType.BOARD_IMAGE, boardId));
-        deletedImageFiles.forEach(fileService::deleteFile);
     }
 
     @Transactional

--- a/src/main/java/com/bmilab/backend/domain/board/service/BoardService.java
+++ b/src/main/java/com/bmilab/backend/domain/board/service/BoardService.java
@@ -101,6 +101,7 @@ public class BoardService {
         validateBoardAccessPermission(user, board);
 
         fileService.deleteAllFileByDomainTypeAndEntityId(FileDomainType.BOARD, board.getId());
+        fileService.deleteAllFileByDomainTypeAndEntityId(FileDomainType.BOARD_IMAGE, board.getId());
 
         boardRepository.delete(board);
     }

--- a/src/main/java/com/bmilab/backend/domain/file/controller/FileApi.java
+++ b/src/main/java/com/bmilab/backend/domain/file/controller/FileApi.java
@@ -24,7 +24,6 @@ public interface FileApi {
             }
     )
     ResponseEntity<FilePresignedUrlResponse> generatePresignedUrl(
-            @RequestParam FileDomainType domainType,
             @RequestParam String fileName,
             @RequestParam String contentType
     );

--- a/src/main/java/com/bmilab/backend/domain/file/controller/FileController.java
+++ b/src/main/java/com/bmilab/backend/domain/file/controller/FileController.java
@@ -30,11 +30,11 @@ public class FileController implements FileApi {
 
     @GetMapping("/presigned-url")
     public ResponseEntity<FilePresignedUrlResponse> generatePresignedUrl(
-            @RequestParam FileDomainType domainType, @RequestParam String fileName, @RequestParam String contentType
+            @RequestParam String fileName,
+            @RequestParam String contentType
     ) {
 
         return ResponseEntity.ok(fileService.generatePresignedUrl(
-                domainType,
                 URLDecoder.decode(fileName, StandardCharsets.UTF_8),
                 URLDecoder.decode(contentType, StandardCharsets.UTF_8)
         ));

--- a/src/main/java/com/bmilab/backend/domain/file/dto/request/UploadFileRequest.java
+++ b/src/main/java/com/bmilab/backend/domain/file/dto/request/UploadFileRequest.java
@@ -23,10 +23,6 @@ public record UploadFileRequest(
 
         @Schema(description = "파일 크기 (바이트 단위)", example = "1024")
         @Min(value = 1, message = "파일 크기는 1바이트 이상이어야 합니다.")
-        long size,
-
-        @Schema(description = "파일 도메인 타입", example = "PROJECT")
-        @NotNull(message = "파일 도메인 타입은 필수입니다.")
-        FileDomainType domainType
+        long size
 ) {
 }

--- a/src/main/java/com/bmilab/backend/domain/file/enums/FileDomainType.java
+++ b/src/main/java/com/bmilab/backend/domain/file/enums/FileDomainType.java
@@ -1,5 +1,5 @@
 package com.bmilab.backend.domain.file.enums;
 
 public enum FileDomainType {
-    PROJECT, TIMELINE, REPORT, BOARD
+    PROJECT, TIMELINE, REPORT, BOARD, BOARD_IMAGE, TEMP
 }

--- a/src/main/java/com/bmilab/backend/domain/file/repository/FileInformationRepository.java
+++ b/src/main/java/com/bmilab/backend/domain/file/repository/FileInformationRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileInformationRepository extends JpaRepository<FileInformation, UUID> {
     List<FileInformation> findAllByDomainTypeAndEntityId(FileDomainType domainType, Long entityId);
+
+    List<FileInformation> findAllByDomainType(FileDomainType domainType);
 }

--- a/src/main/java/com/bmilab/backend/domain/file/service/FileSchedulerService.java
+++ b/src/main/java/com/bmilab/backend/domain/file/service/FileSchedulerService.java
@@ -1,0 +1,32 @@
+package com.bmilab.backend.domain.file.service;
+
+import com.bmilab.backend.domain.file.entity.FileInformation;
+import com.bmilab.backend.domain.file.enums.FileDomainType;
+import com.bmilab.backend.domain.file.repository.FileInformationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileSchedulerService {
+
+    private final FileInformationRepository fileInformationRepository;
+
+    //매일 오전 4시에 임시 파일들 삭제
+    @Transactional
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    public void deleteAllTempFiles() {
+        log.info("임시 파일 삭제 시작");
+        List<FileInformation> files = fileInformationRepository.findAllByDomainType(FileDomainType.TEMP);
+        log.info("[삭제할 파일 목록]");
+        files.forEach(file -> log.info("- fileId={}, fileName={}", file.getId(), file.getName()));
+        fileInformationRepository.deleteAll(files);
+        log.info("임시 파일 삭제 완료");
+    }
+}

--- a/src/main/java/com/bmilab/backend/domain/file/service/FileService.java
+++ b/src/main/java/com/bmilab/backend/domain/file/service/FileService.java
@@ -51,14 +51,14 @@ public class FileService {
 
     @Transactional
     public FileSummary uploadFile(UploadFileRequest request) {
-        String fileKey = request.domainType().name().toLowerCase() + "/" + request.uuid() + "_" + URLEncoder.encode(
+        String fileKey = "temp/" + request.uuid() + "_" + URLEncoder.encode(
                 request.fileName(), StandardCharsets.UTF_8);
 
         FileInformation fileInformation = FileInformation.builder()
                 .id(request.uuid())
                 .name(request.fileName())
                 .extension(request.extension())
-                .domainType(request.domainType())
+                .domainType(FileDomainType.TEMP)
                 .size(request.size())
                 .uploadUrl(s3Service.getUploadedFileUrl(fileKey))
                 .build();

--- a/src/main/java/com/bmilab/backend/domain/project/service/TimelineService.java
+++ b/src/main/java/com/bmilab/backend/domain/project/service/TimelineService.java
@@ -30,7 +30,6 @@ public class TimelineService {
     private final TimelineRepository timelineRepository;
     private final ProjectRepository projectRepository;
     private final FileService fileService;
-    private final FileInformationRepository fileInformationRepository;
     private final UserService userService;
     private final ProjectService projectService;
 
@@ -61,10 +60,7 @@ public class TimelineService {
                 .build();
 
         timelineRepository.save(timeline);
-
-        List<FileInformation> files = fileInformationRepository.findAllById(request.fileIds());
-
-        files.forEach(file -> file.updateDomain(FileDomainType.TIMELINE, timeline.getId()));
+        fileService.updateAllFileDomainByIds(request.fileIds(), FileDomainType.TIMELINE, timeline.getId());
     }
 
     public TimelineFindAllResponse getAllTimelinesByProjectId(Long projectId) {
@@ -107,9 +103,7 @@ public class TimelineService {
                 request.summary()
         );
 
-        List<FileInformation> files = fileInformationRepository.findAllById(request.fileIds());
-
-        files.forEach(file -> file.updateDomain(FileDomainType.TIMELINE, timeline.getId()));
+        fileService.syncFiles(request.fileIds(), FileDomainType.TIMELINE, timeline.getId());
     }
 
     @Transactional

--- a/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/bmilab/backend/domain/report/service/ReportService.java
@@ -63,9 +63,7 @@ public class ReportService {
 
         reportRepository.save(report);
 
-        List<FileInformation> files = fileInformationRepository.findAllById(request.fileIds());
-
-        files.forEach(file -> file.updateDomain(FileDomainType.REPORT, report.getId()));
+        fileService.updateAllFileDomainByIds(request.fileIds(), FileDomainType.REPORT, report.getId());
     }
 
 
@@ -84,9 +82,7 @@ public class ReportService {
 
         report.update(project, request.date(), request.content());
 
-        List<FileInformation> files = fileInformationRepository.findAllById(request.fileIds());
-
-        files.forEach(file -> file.updateDomain(FileDomainType.REPORT, report.getId()));
+        fileService.syncFiles(request.fileIds(), FileDomainType.REPORT, report.getId());
     }
 
     public ReportFindAllResponse getReportsByCurrentUser(

--- a/src/main/java/com/bmilab/backend/global/external/s3/S3Service.java
+++ b/src/main/java/com/bmilab/backend/global/external/s3/S3Service.java
@@ -79,7 +79,12 @@ public class S3Service {
 
     public void moveFileDirectory(String fileUrl, String previousDirectory, String newDirectory) {
         String fileKey = getS3Key(fileUrl);
-        String newFileKey = fileKey.replace(previousDirectory + "/", newDirectory + "/");
+        String previousDirectoryByProfile = ((!previousDirectory.equals("temp")) && (activeProfile.equals("dev"))) ?
+                "dev/" + previousDirectory :
+                previousDirectory;
+        String newDirectoryByProfile = (activeProfile.equals("dev")) ? "dev/" + newDirectory : newDirectory;
+        String newFileKey = fileKey.replace(previousDirectoryByProfile + "/", newDirectoryByProfile + "/");
+
         amazonS3.copyObject(new CopyObjectRequest(bucket, fileKey, bucket, newFileKey));
         amazonS3.deleteObject(bucket, fileKey);
     }

--- a/src/main/java/com/bmilab/backend/global/external/s3/S3Service.java
+++ b/src/main/java/com/bmilab/backend/global/external/s3/S3Service.java
@@ -2,6 +2,7 @@ package com.bmilab.backend.global.external.s3;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -74,6 +75,13 @@ public class S3Service {
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
+    }
+
+    public void moveFileDirectory(String fileUrl, String previousDirectory, String newDirectory) {
+        String fileKey = getS3Key(fileUrl);
+        String newFileKey = fileKey.replace(previousDirectory + "/", newDirectory + "/");
+        amazonS3.copyObject(new CopyObjectRequest(bucket, fileKey, bucket, newFileKey));
+        amazonS3.deleteObject(bucket, fileKey);
     }
 
     public URL generatePresignedUploadUrl(String key, String contentType, long expirationInMinutes) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#79 #81 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

리팩터링: 파일 도메인 업데이트 및 동기화 로직
- FileService에 syncFiles, findFileById 메서드 추가
- 파일 도메인 업데이트 및 동기화 로직을 FileService로 중앙화
- 서비스 클래스에서 직접 Repository 접근 제거
- 수동으로 처리되던 파일 업데이트/삭제 로직을 FileService 메서드 호출로 대체하여 일관성 및 유지보수성 향상

기능 추가: 게시판 이미지 파일 관리
- 게시판 요청 및 서비스 계층에서 이미지 파일 관리 기능 지원
- 일반 파일과 이미지 파일을 구분하여 처리 가능하도록 개선
- 파일 업데이트/삭제 로직을 FileService로 일원화
- BOARD_IMAGE, TEMP 도메인 타입 추가
- S3Service에 디렉터리 간 파일 이동 기능 추가
- Presigned URL 생성 시 domainType 파라미터 제거, 기본 TEMP 디렉터리 사용으로 단순화

- 오전 4시에 DB 내의 임시 파일 데이터를 일괄 삭제하도록 구현하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
